### PR TITLE
- fix documentation for excerpt_html

### DIFF
--- a/pages/documentation/3-Templates.md
+++ b/pages/documentation/3-Templates.md
@@ -661,7 +661,7 @@ _Examples:_
 Reads characters before `<!-- excerpt -->` or `<!-- break -->` tag.
 
 ```twig
-{{ string|excerpt_html(separator, capture) }}
+{{ string|excerpt_html({separator, capture}) }}
 ```
 
 | Option    | Description                                           | Type    | Default         |
@@ -673,7 +673,8 @@ _Examples:_
 
 ```twig
 {{ variable|excerpt_html }}
-{{ variable|excerpt_html('excerpt|break', 'before') }}
+{{ variable|excerpt_html({separator: 'excerpt|break', capture:'before'}) }}
+{{ variable|excerpt_html({capture:'after'}) }}
 ```
 
 ### to_css


### PR DESCRIPTION
Hi Arnaud,

When compiling with the following code:
```twig
{{ variable|excerpt_html('excerpt|break', 'after') }}
```

The following error is displayed:
```
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to Cecil\Renderer\Twig\Extension::excerptHtml() must be of the type array, string given, called in /.cache/templates/51/51c7e49e3c03321c4795651c38061f495d0dbf162c7b8934d6ff8f0ecd3e61e4.php on line 90 and defined in phar:///usr/local/bin/cecil/src/Renderer/Twig/Extension.php:621
```

I propose with this PR, a solution.

Best regards,

Matthieu